### PR TITLE
v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,14 @@ You use collections in the same way you add rule sets: By adding them to the `ex
 
 The following is a overview of the rules each collection includes:
 
-|                     | `default` | `react-recommended` | `typescript-reecommended` | `react-typescript-recommended` |
+|                     | `default` | `react-recommended` | `typescript-recommended` | `react-typescript-recommended` |
 | ------------------- | --------- | ------------------- | ------------------------- | ------------------------------ |
 | javascript          | ✅        | ✅                  | ✅                        | ✅                             |
 | prettier            | ✅        | ✅                  | ✅                        | ✅                             |
-| react               |           | ✅                  |                           | ✅                             |
-| prettier-react      |           | ✅                  |                           | ✅                             |
-| typescript          |           |                     | ✅                        | ✅                             |
-| prettier-typescript |           |                     | ✅                        | ✅                             |
+| react               | ✅        | ✅                  |                           | ✅                             |
+| prettier-react      | ✅        | ✅                  |                           | ✅                             |
+| typescript          | ✅        |                     | ✅                        | ✅                             |
+| prettier-typescript | ✅        |                     | ✅                        | ✅                             |
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ _These files should be placed in the root directory, also for multi-workspace mo
 ```
 
 _We recommend `lint:ignore-warnings` and `lint:prettier-check` to be run on CI test tasks, to prevent PRs with errors to be merged to master._
+_These tasks should be placed in the root directory, also for multi-workspace mono repos_
+
+### `wercker.yml`
+
+If we are (still) using wercker when you read this, add steps to the test job for all branches that run the following checks:
+
+```
+linting:
+  steps:
+    - script:
+      name: ESLint check
+      code: npm run lint:ignore-warnings
+    - script:
+      name: Prettier check
+      code: npm run lint:prettier-check
+```
 
 ### Commit hooks
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ You also want an ignore-file, ignoring all dist, build and node_modules folders:
 **/dist/*
 **/build/*
 **/node-modules/*
+**/__mocks__/*
+**/.cache/*
+**/public/*
+coverage
+*.css
+*.json
+prettier.config.js
+```
+
+### `prettier.config.js`
+```
+const commonConfig = require('@askeladden/eslint-config-askeladden/prettier.config');
+
+module.exports = commonConfig;
 ```
 
 _These files should be placed in the root directory, also for multi-workspace mono repos_

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -3,9 +3,6 @@ const jsRules = require('./rules');
 module.exports = {
   extends: ['airbnb-base', 'plugin:import/errors', 'plugin:import/warnings'],
   parser: 'babel-eslint',
-  plugins: [
-    "jest",
-    "unused-imports"
-  ],
+  plugins: ['jest', 'unused-imports'],
   rules: jsRules,
 };

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -4,7 +4,8 @@ module.exports = {
   extends: ['airbnb-base', 'plugin:import/errors', 'plugin:import/warnings'],
   parser: 'babel-eslint',
   plugins: [
-    "jest"
+    "jest",
+    "unused-imports"
   ],
   rules: jsRules,
 };

--- a/javascript/rules.js
+++ b/javascript/rules.js
@@ -9,9 +9,9 @@ module.exports = {
   'no-undef': 2,
 
   // Do not allow unused variables – a common cause of bugs. Use plugin.
-  "no-unused-vars": 0,
-  "unused-imports/no-unused-vars": 2,
-  "unused-imports/no-unused-imports": 2,
+  'no-unused-vars': 0,
+  'unused-imports/no-unused-vars': 2,
+  'unused-imports/no-unused-imports': 2,
 
   'no-underscore-dangle': 0,
 
@@ -19,7 +19,7 @@ module.exports = {
   'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
 
   // Do not require default exports
-  "import/extensions": 0,
+  'import/extensions': 0,
   'import/order': [
     'error',
     {
@@ -28,46 +28,54 @@ module.exports = {
   ],
 
   // Do not use a variable before it's define, unless it's accessed after initialization
-  "no-use-before-define": [
+  'no-use-before-define': [
     2,
     {
-      "functions": false,
-      "classes": false,
-      "variables": false
-    }
+      functions: false,
+      classes: false,
+      variables: false,
+    },
   ],
 
   // Prevent accidental console logs
-  "no-console": 2,
+  'no-console': 2,
 
   // Allow implicit return of value undefined in functions where values can also be returned
-  "consistent-return": 0,
+  'consistent-return': 0,
 
   // Required by some libraries, including typeorm
-  "class-methods-use-this": 0,
+  'class-methods-use-this': 0,
 
   // Class attributes look better without empty lines between each
-  "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
+  'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
 
   // Disallow depending on libraries not inside package.json
-  "import/no-extraneous-dependencies": [
+  'import/no-extraneous-dependencies': [
     2,
     // For test files, allow libraries only to be specified in devDependencies
-    { "devDependencies": ["**/tests/**", "**/*.test.*", "**/*.spec.*", "**/.storybook/**", "**/*.stories.*"] }
+    {
+      devDependencies: [
+        '**/tests/**',
+        '**/*.test.*',
+        '**/*.spec.*',
+        '**/.storybook/**',
+        '**/*.stories.*',
+      ],
+    },
   ],
 
   // The readability varies depending on the case. No need to enforce a rule.
-  "prefer-template": 0,
-  "prefer-destructuring": 0,
+  'prefer-template': 0,
+  'prefer-destructuring': 0,
   'import/prefer-default-export': 0,
 
   // We use short-circuit and ternary function calls, though they can be less
   //   readable. Could be considered removed at a later stage.
-  "no-unused-expressions": [
+  'no-unused-expressions': [
     2,
-    { "allowShortCircuit": true, "allowTernary": true, "allowTaggedTemplates": true }
+    { allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true },
   ],
 
   // Allow second parameter to be optional in parseInt
-  "radix": 0,
+  radix: 0,
 };

--- a/javascript/rules.js
+++ b/javascript/rules.js
@@ -8,8 +8,10 @@ module.exports = {
   // Do not allow use of undefined variables
   'no-undef': 2,
 
-  // Do not allow unused variables – a common cause of bugs
-  "no-unused-vars": 2,
+  // Do not allow unused variables – a common cause of bugs. Use plugin.
+  "no-unused-vars": 0,
+  "unused-imports/no-unused-vars": 2,
+  "unused-imports/no-unused-imports": 2,
 
   'no-underscore-dangle': 0,
 

--- a/javascript/rules.js
+++ b/javascript/rules.js
@@ -45,7 +45,7 @@ module.exports = {
   "import/no-extraneous-dependencies": [
     2,
     // For test files, allow libraries only to be specified in devDependencies
-    { "devDependencies": ["**/*.test.ts", "**/*.spec.ts"] }
+    { "devDependencies": ["**/*.test.*", "**/*.spec.*", "**/.storybook/**", "**/*.stories.*"] }
   ],
 
   // The readability varies depending on the case. No need to enforce a rule.

--- a/javascript/rules.js
+++ b/javascript/rules.js
@@ -41,6 +41,9 @@ module.exports = {
   // Allow implicit return of value undefined in functions where values can also be returned
   "consistent-return": 0,
 
+  // Required by some libraries, including typeorm
+  "class-methods-use-this": 0,
+
   // Disallow depending on libraries not inside package.json
   "import/no-extraneous-dependencies": [
     2,

--- a/javascript/rules.js
+++ b/javascript/rules.js
@@ -45,7 +45,7 @@ module.exports = {
   "import/no-extraneous-dependencies": [
     2,
     // For test files, allow libraries only to be specified in devDependencies
-    { "devDependencies": ["**/*.test.*", "**/*.spec.*", "**/.storybook/**", "**/*.stories.*"] }
+    { "devDependencies": ["**/tests/**", "**/*.test.*", "**/*.spec.*", "**/.storybook/**", "**/*.stories.*"] }
   ],
 
   // The readability varies depending on the case. No need to enforce a rule.

--- a/javascript/rules.js
+++ b/javascript/rules.js
@@ -44,6 +44,9 @@ module.exports = {
   // Required by some libraries, including typeorm
   "class-methods-use-this": 0,
 
+  // Class attributes look better without empty lines between each
+  "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
+
   // Disallow depending on libraries not inside package.json
   "import/no-extraneous-dependencies": [
     2,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/askeladdenco/eslint-config.git"
+    "url": "git+https://github.com/askeladdenco/eslint-config-askeladden.git"
   },
   "author": "Tomas Fagerbekk <tomas@askeladden.co>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   ],
   "main": "index.js",
   "scripts": {
-    "release": "np"
+    "release": "np",
+    "lint:prettier-check": "prettier --check \"**/*.{js,jsx,ts,tsx,json}\"",
+    "lint:prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,json}\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^4.0.8",
+    "eslint-plugin-unused-imports": "^1.1.0",
     "prettier": "^2.0.5"
   },
   "devDependencies": {

--- a/prettier-react/index.js
+++ b/prettier-react/index.js
@@ -1,4 +1,7 @@
+const rules = require('../prettier/rules');
+
 module.exports = {
   extends: ['prettier/react'],
+  rules,
   parser: 'babel-eslint',
 };

--- a/prettier-typescript/index.js
+++ b/prettier-typescript/index.js
@@ -1,5 +1,8 @@
+const rules = require('../prettier/rules');
+
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
+  rules: rules,
   extends: [
     'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
   ],

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,9 @@
 module.exports = {
-  printWidth: 80,
+  printWidth: 100,
   singleQuote: true,
   trailingComma: 'all',
   bracketSpacing: true,
   jsxBracketSameLine: true,
+  semi: true,
+  useTabs: false,
 };

--- a/prettier/index.js
+++ b/prettier/index.js
@@ -1,13 +1,12 @@
+const rules = require('./rules');
+
 module.exports = {
   extends: [
     'plugin:prettier/recommended', // enables-eslint-plugin-prettier, sets the prettier/prettier rule to "error", extends eslint-config-prettier so that we can set prettier options in .prettierrc
   ],
-  rules: {
-    // Prettier errors are expected to be fixed automatically. No need to also hint in IDE.
-    "prettier/prettier": 0
-  },
+  rules: rules,
   // "plugins": [
-  //   "prettier", enabled by the plugin;prettier/recommneded extension
+  //   "prettier", enabled by the plugin;prettier/recommended extension
   // ],
   parser: 'babel-eslint',
 };

--- a/prettier/rules.js
+++ b/prettier/rules.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // Prettier errors are expected to be fixed automatically. No need to also hint in IDE.
+  'prettier/prettier': 0,
+};

--- a/react-native-typescript-recommended/index.js
+++ b/react-native-typescript-recommended/index.js
@@ -1,26 +1,24 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
-  extends: [
-    '../react-typescript-recommended',
-  ].map(require.resolve),
+  extends: ['../react-typescript-recommended'].map(require.resolve),
   settings: {
-    "import/resolver": {
-      "node": {
-        "extensions": [
-          ".js",
-          ".jsx",
-          ".ts",
-          ".tsx",
-          ".web.ts",
-          ".web.tsx",
-          ".native.ts",
-          ".native.tsx",
-          ".android.ts",
-          ".android.tsx",
-          ".ios.ts",
-          ".ios.tsx"
-        ]
-      }
-    }
-  }
+    'import/resolver': {
+      node: {
+        extensions: [
+          '.js',
+          '.jsx',
+          '.ts',
+          '.tsx',
+          '.web.ts',
+          '.web.tsx',
+          '.native.ts',
+          '.native.tsx',
+          '.android.ts',
+          '.android.tsx',
+          '.ios.ts',
+          '.ios.tsx',
+        ],
+      },
+    },
+  },
 };

--- a/react-recommended/index.js
+++ b/react-recommended/index.js
@@ -1,15 +1,8 @@
-
-const jsRules = require('../javascript/rules')
-const reactRules = require('../react/rules')
-const prettierRules = require('../prettier/rules')
+const jsRules = require('../javascript/rules');
+const reactRules = require('../react/rules');
+const prettierRules = require('../prettier/rules');
 
 module.exports = {
-  extends: [
-    '../javascript',
-    '../react',
-    '../prettier',
-    '../prettier-react/',
-  ].map(require.resolve),
-  rules: Object.assign({}, jsRules, reactRules, prettierRules)
-
+  extends: ['../javascript', '../react', '../prettier', '../prettier-react/'].map(require.resolve),
+  rules: Object.assign({}, jsRules, reactRules, prettierRules),
 };

--- a/react-recommended/index.js
+++ b/react-recommended/index.js
@@ -1,3 +1,8 @@
+
+const jsRules = require('../javascript/rules')
+const reactRules = require('../react/rules')
+const prettierRules = require('../prettier/rules')
+
 module.exports = {
   extends: [
     '../javascript',
@@ -5,4 +10,6 @@ module.exports = {
     '../prettier',
     '../prettier-react/',
   ].map(require.resolve),
+  rules: Object.assign({}, jsRules, reactRules, prettierRules)
+
 };

--- a/react-typescript-recommended/index.js
+++ b/react-typescript-recommended/index.js
@@ -1,3 +1,8 @@
+const jsRules = require('../javascript/rules');
+const tsRules = require('../typescript/rules');
+const prettierRules = require('../prettier/rules');
+const reactRules = require('../react/rules');
+
 module.exports = {
   parser: '@typescript-eslint/parser',
   extends: [
@@ -8,6 +13,7 @@ module.exports = {
     '../prettier-react/',
     '../prettier-typescript/',
   ].map(require.resolve),
+  rules: Object.assign({}, jsRules, tsRules, reactRules, prettierRules),
   settings: {
     'import/resolver': {
       node: {

--- a/react/index.js
+++ b/react/index.js
@@ -1,12 +1,7 @@
 const reactRules = require('./rules');
 
 module.exports = {
-  extends: [
-    'airbnb',
-    'airbnb/hooks',
-    'plugin:react/recommended',
-    'plugin:jsx-a11y/recommended',
-  ],
+  extends: ['airbnb', 'airbnb/hooks', 'plugin:react/recommended', 'plugin:jsx-a11y/recommended'],
   parser: 'babel-eslint',
-  rules: reactRules
+  rules: reactRules,
 };

--- a/react/index.js
+++ b/react/index.js
@@ -1,4 +1,4 @@
-const jsRules = require('../javascript/rules');
+const reactRules = require('./rules');
 
 module.exports = {
   extends: [
@@ -8,58 +8,5 @@ module.exports = {
     'plugin:jsx-a11y/recommended',
   ],
   parser: 'babel-eslint',
-  rules: Object.assign({}, jsRules, {
-    // React's PropTypes are discouraged
-    'react/require-default-props': 0,
-    "react/no-unused-prop-types": 0,
-    "react/prop-types": 0,
-
-    // Exhaustive deps feels unnecessary. Consider settings this to 2 when we get burnt.
-    "react-hooks/exhaustive-deps": 1,
-
-    // Only for styling/consistency, often with undesirable defaults.
-    // Can be considered in individual repos.
-    "react/jsx-curly-brace-presence": 0,
-    "react/static-property-placement": 0,
-    "react/destructuring-assignment": 0,
-    "react/state-in-constructor": 0,
-
-    // Potentially dangerous, but too practical to let go of.
-    "react/jsx-props-no-spreading": 1,
-
-    // Does not support dynamic type prop, which we want.
-    // ref https://github.com/yannickcr/eslint-plugin-react/issues/1555
-    "react/button-has-type": 0,
-
-    // Allow JSX in .js files
-    'react/jsx-filename-extension': [0, { extensions: ['.jsx'] }],
-
-    // Ordering of react component methods
-    'react/sort-comp': [
-      1,
-      {
-        order: [
-          'type-annotations',
-          'static-methods',
-          'lifecycle',
-          'everything-else',
-          'render',
-        ],
-      },
-    ],
-    'jsx-a11y/label-has-for': [
-      2,
-      {
-        required: {
-          every: ['id'],
-        },
-        allowChildren: false,
-      },
-    ],
-
-    // Allows label-control connection being nested in DOM
-    "jsx-a11y/label-has-associated-control": [2, { "assert": "either" }],
-
-    'react/no-did-mount-set-state': [0],
-  }),
+  rules: reactRules
 };

--- a/react/rules.js
+++ b/react/rules.js
@@ -30,13 +30,7 @@ module.exports = {
   'react/sort-comp': [
     1,
     {
-      order: [
-        'type-annotations',
-        'static-methods',
-        'lifecycle',
-        'everything-else',
-        'render',
-      ],
+      order: ['type-annotations', 'static-methods', 'lifecycle', 'everything-else', 'render'],
     },
   ],
   'jsx-a11y/label-has-for': [

--- a/react/rules.js
+++ b/react/rules.js
@@ -1,0 +1,56 @@
+const jsRules = require('../javascript/rules');
+
+module.exports = {
+  // React's PropTypes are discouraged
+  'react/require-default-props': 0,
+  'react/no-unused-prop-types': 0,
+  'react/prop-types': 0,
+
+  // Exhaustive deps feels unnecessary. Consider settings this to 2 when we get burnt.
+  'react-hooks/exhaustive-deps': 1,
+
+  // Only for styling/consistency, often with undesirable defaults.
+  // Can be considered in individual repos.
+  'react/jsx-curly-brace-presence': 0,
+  'react/static-property-placement': 0,
+  'react/destructuring-assignment': 0,
+  'react/state-in-constructor': 0,
+
+  // Potentially dangerous, but too practical to let go of.
+  'react/jsx-props-no-spreading': 1,
+
+  // Does not support dynamic type prop, which we want.
+  // ref https://github.com/yannickcr/eslint-plugin-react/issues/1555
+  'react/button-has-type': 0,
+
+  // Allow JSX in .js files
+  'react/jsx-filename-extension': [0, { extensions: ['.jsx'] }],
+
+  // Ordering of react component methods
+  'react/sort-comp': [
+    1,
+    {
+      order: [
+        'type-annotations',
+        'static-methods',
+        'lifecycle',
+        'everything-else',
+        'render',
+      ],
+    },
+  ],
+  'jsx-a11y/label-has-for': [
+    2,
+    {
+      required: {
+        every: ['id'],
+      },
+      allowChildren: false,
+    },
+  ],
+
+  // Allows label-control connection being nested in DOM
+  'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
+
+  'react/no-did-mount-set-state': [0],
+};

--- a/typescript-recommended/index.js
+++ b/typescript-recommended/index.js
@@ -3,11 +3,8 @@ const tsRules = require('../typescript/rules');
 const prettierRules = require('../prettier/rules');
 
 module.exports = {
-  extends: [
-    '../javascript',
-    '../typescript',
-    '../prettier',
-    '../prettier-typescript/',
-  ].map(require.resolve),
+  extends: ['../javascript', '../typescript', '../prettier', '../prettier-typescript/'].map(
+    require.resolve,
+  ),
   rules: Object.assign({}, jsRules, tsRules, prettierRules),
 };

--- a/typescript-recommended/index.js
+++ b/typescript-recommended/index.js
@@ -1,3 +1,7 @@
+const jsRules = require('../javascript/rules');
+const tsRules = require('../typescript/rules');
+const prettierRules = require('../prettier/rules');
+
 module.exports = {
   extends: [
     '../javascript',
@@ -5,4 +9,5 @@ module.exports = {
     '../prettier',
     '../prettier-typescript/',
   ].map(require.resolve),
+  rules: Object.assign({}, jsRules, tsRules, prettierRules),
 };

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -37,6 +37,9 @@ module.exports = {
       }
     ],
 
+    // Libraries like typedi inject based on constructur params.
+    'no-useless-constructor': 'off',
+
     "@typescript-eslint/ban-types": [
       "error",
       {

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -8,6 +8,9 @@ module.exports = {
     "no-unused-vars": 0,
     "@typescript-eslint/no-unused-vars": 2,
 
+    // Avoid unnecessary imports
+    "unused-imports/no-unused-imports-ts": 2,
+
     '@typescript-eslint/indent': ['error', 2],
     '@typescript-eslint/camelcase': 0,
     "@typescript-eslint/no-inferrable-types": 0,

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -1,4 +1,4 @@
-const jsRules = require('../javascript/rules')
+const jsRules = require('../javascript/rules');
 const tsRules = require('./rules');
 
 module.exports = {

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -1,73 +1,12 @@
+const jsRules = require('../javascript/rules')
+const tsRules = require('./rules');
+
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
   ],
-  rules: {
-    '@typescript-eslint/indent': ['error', 2],
-    '@typescript-eslint/camelcase': 0,
-    "@typescript-eslint/no-inferrable-types": 0,
-    "@typescript-eslint/explicit-function-return-type": 0,
-    "@typescript-eslint/explicit-module-boundary-types": 0,
-    "@typescript-eslint/interface-name-prefix": 0,
-    "@typescript-eslint/no-empty-interface": 0,
-
-    // Do not allow unused variables – a common cause of bugs. Use plugin.
-    "@typescript-eslint/no-unused-vars": 0,
-    "unused-imports/no-unused-vars": 2,
-    "unused-imports/no-unused-imports": 2,
-
-    // It should not be necessary to add two comments in TS-ignore cases
-    "@typescript-eslint/ban-ts-comment": 0,
-
-    // Using var x = require(...) is so uncommon, that it's on purpse when we do it
-    "@typescript-eslint/no-var-requires": 0,
-
-    // Sometimes you need empty functions to fulfill required parameters.
-    "@typescript-eslint/no-empty-function": 0,
-
-    // Needed to allow for ReturnType typedef.
-    "no-use-before-define": 0,
-    "@typescript-eslint/no-use-before-define": [
-      2,
-      {
-        "functions": false,
-        "classes": false,
-        "variables": false,
-        "typedefs": false
-      }
-    ],
-
-    // Libraries like typedi inject based on constructur params.
-    'no-useless-constructor': 'off',
-
-    "@typescript-eslint/ban-types": [
-      "error",
-      {
-        "types": {
-          "String": {
-            "message": "Use string instead",
-            "fixWith": "string"
-          },
-
-          "{}": {
-            "message":
-              "{} allows a function to be called with any argument.\n" +
-              "  - Consider removing the typing entirely.\n" +
-              "  - If you explicitly want an empty object, use Record\<never, never>.\n" +
-              "  - If you want to allow anything (discouraged), use unknown.",
-            "fixWith": ""
-          },
-          "React.FC": {
-            "message": "You do not need to type the return type of a React component. React.FC is discouraged. See https://github.com/facebook/create-react-app/pull/8177"
-          },
-          "FC": {
-            "message": "You do not need to type the return type of a React component. React.FC is discouraged. See https://github.com/facebook/create-react-app/pull/8177"
-          }
-        }
-      }
-    ],
-  },
+  rules: Object.assign({}, jsRules, tsRules),
   settings: {
     'import/resolver': {
       node: {

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -4,13 +4,6 @@ module.exports = {
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
   ],
   rules: {
-    // Extends javascript rule to include types and interfaces
-    "no-unused-vars": 0,
-    "@typescript-eslint/no-unused-vars": 2,
-
-    // Avoid unnecessary imports
-    "unused-imports/no-unused-imports-ts": 2,
-
     '@typescript-eslint/indent': ['error', 2],
     '@typescript-eslint/camelcase': 0,
     "@typescript-eslint/no-inferrable-types": 0,
@@ -18,6 +11,11 @@ module.exports = {
     "@typescript-eslint/explicit-module-boundary-types": 0,
     "@typescript-eslint/interface-name-prefix": 0,
     "@typescript-eslint/no-empty-interface": 0,
+
+    // Do not allow unused variables – a common cause of bugs. Use plugin.
+    "@typescript-eslint/no-unused-vars": 0,
+    "unused-imports/no-unused-vars": 2,
+    "unused-imports/no-unused-imports": 2,
 
     // It should not be necessary to add two comments in TS-ignore cases
     "@typescript-eslint/ban-ts-comment": 0,

--- a/typescript/rules.js
+++ b/typescript/rules.js
@@ -1,0 +1,68 @@
+module.exports = {
+  '@typescript-eslint/indent': ['error', 2],
+  '@typescript-eslint/camelcase': 0,
+  '@typescript-eslint/no-inferrable-types': 0,
+  '@typescript-eslint/explicit-function-return-type': 0,
+  '@typescript-eslint/explicit-module-boundary-types': 0,
+  '@typescript-eslint/interface-name-prefix': 0,
+  '@typescript-eslint/no-empty-interface': 0,
+
+  // Do not allow unused variables – a common cause of bugs. Use plugin.
+  '@typescript-eslint/no-unused-vars': 0,
+  'unused-imports/no-unused-vars': 2,
+  'unused-imports/no-unused-imports': 2,
+
+  // It should not be necessary to add two comments in TS-ignore cases
+  '@typescript-eslint/ban-ts-comment': 0,
+
+  // Using var x = require(...) is so uncommon, that it's on purpse when we do it
+  '@typescript-eslint/no-var-requires': 0,
+
+  // Sometimes you need empty functions to fulfill required parameters.
+  '@typescript-eslint/no-empty-function': 0,
+
+  // Needed to allow for ReturnType typedef.
+  'no-use-before-define': 0,
+  '@typescript-eslint/no-use-before-define': [
+    2,
+    {
+      functions: false,
+      classes: false,
+      variables: false,
+      typedefs: false,
+    },
+  ],
+
+  // Libraries like typedi inject based on constructur params.
+  'no-useless-constructor': 'off',
+
+  '@typescript-eslint/ban-types': [
+    'error',
+    {
+      types: {
+        String: {
+          message: 'Use string instead',
+          fixWith: 'string',
+        },
+
+        '{}': {
+          message:
+            '{} allows a function to be called with any argument.\n' +
+            '  - Consider removing the typing entirely.\n' +
+            '  - If you explicitly want any Record, use Record<string, unknown>.\n' +
+            '  - If you explicitly want an empty object, use Record<never, never>.\n' +
+            '  - If you want to allow anything (discouraged), use unknown.',
+          fixWith: '',
+        },
+        'React.FC': {
+          message:
+            'You do not need to type the return type of a React component. React.FC is discouraged. See https://github.com/facebook/create-react-app/pull/8177',
+        },
+        FC: {
+          message:
+            'You do not need to type the return type of a React component. React.FC is discouraged. See https://github.com/facebook/create-react-app/pull/8177',
+        },
+      },
+    },
+  ],
+};


### PR DESCRIPTION
- Add docs on prettier + wercker
- New import resolver addon, which autosorts and removes unused imports automatically
- Fix bad rules inheritence (when not using default config)

Rule changes:
- accept devDependencies in storybook files, `tests` folders, and `tsx/js/jsx` files.
- Allow non-static class methods that do not use `this` (typeorm)
- Allow class members having one-line attributes/methods without empty line between them
- Enables/disables rules that we set "everywhere".